### PR TITLE
Update readthedocs and setup with extra pyqt5 dependency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,3 +25,4 @@ python:
       path: .
       extra_requirements:
         - docs
+        - pyqt5

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,8 @@ setup(
     extras_require={
         'docs': ['sphinx', 'recommonmark', 'sphinx_bootstrap_theme'],
         'tests': ['pytest', 'coverage'],
+        'pyqt5': ['pyqt5'],
+        'PySide2': ['PySide2'],
     },
 
     # If there are data files included in your packages that need to be


### PR DESCRIPTION
Fixes problem with autodoc trying to import the xicam.plugins module and then qtpy, during readthedocs build.

<details>
<summary>Error details</summary>
<pre>
WARNING: autodoc: failed to import simplefunction 'plugins.EZPlugin' from module 'xicam'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/xi-cam2/envs/latest/lib/python3.7/site-packages/qtpy/__init__.py", line 202, in <module>
    from PySide import __version__ as PYSIDE_VERSION  # analysis:ignore
ModuleNotFoundError: No module named 'PySide'
</pre>
</details>