### PR TITLE
Update .travis.yml to avoid attrs version conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - qtbase5-dev
 install:
 - pip install cx_freeze==6.0b1
+- pip install databroker # avoid attrs version conflict
 - pip install coveralls pytest
 - pip install git+https://github.com/lbl-camera/Xi-cam.core.git
 - pip install git+https://github.com/lbl-camera/Xi-cam.plugins.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ addons:
     packages:
     - qtbase5-dev
 install:
+- pip install --upgrade attrs>=17.4.0 # travis python3.6 has attrs 17.3.0 installed
 - pip install cx_freeze==6.0b1
-- pip install databroker # avoid attrs version conflict
 - pip install coveralls pytest
 - pip install git+https://github.com/lbl-camera/Xi-cam.core.git
 - pip install git+https://github.com/lbl-camera/Xi-cam.plugins.git


### PR DESCRIPTION
Conflict is:
`error: attrs 17.3.0 is installed but attrs>=17.4.0 is required by {'jsonschema'}`

It looks like:
pytest installs attrs 17.3.0
databroker -> jsonschema requires 17.4.0

For some reason, pip was not installing the higher required version. (https://github.com/pypa/pip/issues/5335 looks like a closed pip issue that illustrates the problem)